### PR TITLE
fix: github pages rendering error

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Card Journaling</title>
-    <link rel="stylesheet" href="/style/general.css">
+    <link rel="stylesheet" href="./style/general.css">
 </head>
 <body>
     <nav>


### PR DESCRIPTION
## What does this PR do and why?
Fixes the Github pages rendering error, which was caused by a missing `.` in the stylesheet path.

Fixes #34

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Screenshots or screen recordings
https://github.com/user-attachments/assets/79a35ca8-8d97-4a4e-8995-d726acc23c25



# How Has This Been Tested?
Tested in the browser (see video)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

