### PR TITLE
feat: added HTML framework for shuffle recap

### DIFF
--- a/pages/recap.html
+++ b/pages/recap.html
@@ -43,7 +43,7 @@
       </div>
       <!-- figured that the flip button will be on the card itself rather than the controls-->
       <button id="flipBtn" class="flip-card">Flip Card</button>
-    </div>
+    </div> 
 
     
   </main>

--- a/pages/recap.html
+++ b/pages/recap.html
@@ -18,33 +18,28 @@
   <main>
     <h1>Recap</h1>
 
-    <!-- add shuffle button -->
-    <div class="recap-controls">
-      <button id="shuffleBtn">Shuffle Entry</button>
-    </div>
-
-    <!-- add button to allow to revisit past entries -->
-    <div id="recapDisplay" class="recap-display">
-      <p>Click shuffle to revisit past entry</p>
-    </div>
-
     <!-- card recap -->
     <div id="cardRecap" class="card-recap">
       <div id="cardContent" class="card-content">
+        <!-- placeholder for question mark image-->
+        </div id="questionImage" class="question-icon-placeholder"></div>
         <!-- front of the card, containing prompt and date -->
         <div id="cardFront" class="card-front">
+
           <h3 id="cardPrompt" class="card-prompt">Sample Text! How was your day?</h3>
-          <p id="cardDate" class="card-date">5/22/2025</p>
         </div>
         <!-- back of card, containing response -->
         <div id="cardBack" class="card-back">
           <p id="response" class="user-response">My day was quite reasonable!</p>
         </div>
       </div>
-      <!-- figured that the flip button will be on the card itself rather than the controls-->
-      <button id="flipBtn" class="flip-card">Flip Card</button>
     </div> 
 
+    <p id="cardDate" class="card-date">5/22/2025</p>
+    <!-- button to flip the card -->
+    <button id="shuffleBtn" class="shuffle-card">Shuffle</button>
+    <!-- button the reveal the card -->
+    <button id="revealBtn" class="reveal-card">Reveal</button>
     
   </main>
 

--- a/pages/recap.html
+++ b/pages/recap.html
@@ -27,6 +27,25 @@
     <div id="recapDisplay" class="recap-display">
       <p>Click shuffle to revisit past entry</p>
     </div>
+
+    <!-- card recap -->
+    <div id="cardRecap" class="card-recap">
+      <div id="cardContent" class="card-content">
+        <!-- front of the card, containing prompt and date -->
+        <div id="cardFront" class="card-front">
+          <h3 id="cardPrompt" class="card-prompt">Sample Text! How was your day?</h3>
+          <p id="cardDate" class="card-date">5/22/2025</p>
+        </div>
+        <!-- back of card, containing response -->
+        <div id="cardBack" class="card-back">
+          <p id="response" class="user-response">My day was quite reasonable!</p>
+        </div>
+      </div>
+      <!-- figured that the flip button will be on the card itself rather than the controls-->
+      <button id="flipBtn" class="flip-card">Flip Card</button>
+    </div>
+
+    
   </main>
 
   <script src="/script/recap.js"></script>


### PR DESCRIPTION
## What does this PR do and why?
Added HTML framework for recap.html, specifically adding the card itself and its elements

Fixes #57 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots or screen recordings

![image](https://github.com/user-attachments/assets/0455781b-6785-458a-b297-fdedecf7e23d)

<!--
OPTIONAL: For responsive UI changes, you can use the viewport size table below.
Delete this table if not needed or delete rows that are not relevant to your changes.

| Viewport size   | Before     | After      |
| ----------------| ---------- | ---------- |
| `xs` (<576px)   |            |            |
| `sm` (>=576px)  |            |            |
| `md` (>=768px)  |            |            |
| `lg` (>=992px)  |            |            |
| `xl` (>=1200px) |            |            |
-->

# How Has This Been Tested?

Has been tested through live share, where I ensure added elements actually exist. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

