### PR TITLE
fix: moved eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-puppeteer": "^11.0.0",
     "prettier": "^3.5.3",
-    "puppeteer": "^24.9.0"
-  },
-  "dependencies": {
+    "puppeteer": "^24.9.0",
     "eslint": "^9.27.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## What does this PR do and why?
Moved eslint from the dependency section of our `package.json` to the devDependency section.

Fixes #120 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- CI/CD pipeline still successfully runs—see checks on this PR

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

