### PR TITLE
feat: added new testing for buttons on the homepage

### DIFF
--- a/test/e2e/homepage.e2e.test.js
+++ b/test/e2e/homepage.e2e.test.js
@@ -38,7 +38,9 @@ describe("Test basic user flow from homepage", () => {
   it(`Testing 'new journal entry' button`, async () => {
     console.log(`Testing 'new journal entry' button`);
 
-    let newButton = await page.$(`.home-buttons[onclick="location.href='./pages/create-card.html'"]`);
+    let newButton = await page.$(
+      `.home-buttons[onclick="location.href='./pages/create-card.html'"]`,
+    );
     await newButton.click();
 
     await page.waitForSelector(".card-input");
@@ -53,7 +55,9 @@ describe("Test basic user flow from homepage", () => {
   it(`Testing 'past journal entry' button`, async () => {
     console.log(`Testing 'past journal entry' button`);
 
-    let pastButton = await page.$(`.home-buttons[onclick="location.href='./pages/past-entries.html'"]`);
+    let pastButton = await page.$(
+      `.home-buttons[onclick="location.href='./pages/past-entries.html'"]`,
+    );
     await pastButton.click();
 
     await page.waitForSelector(".calendar");

--- a/test/e2e/homepage.e2e.test.js
+++ b/test/e2e/homepage.e2e.test.js
@@ -35,16 +35,34 @@ describe("Test basic user flow from homepage", () => {
     expect(homeButtons.includes("View past journal entries?")).toBe(true);
   });
 
-  it.skip(`Testing 'new journal entry' button`, async () => {
+  it(`Testing 'new journal entry' button`, async () => {
     console.log(`Testing 'new journal entry' button`);
 
-    // TODO: test that 'new journal entry' button takes user to correct page
+    let newButton = await page.$(`.home-buttons[onclick="location.href='./pages/create-card.html'"]`);
+    await newButton.click();
+
+    await page.waitForSelector(".card-input");
+
+    let card = await page.$(".card-input");
+
+    expect(card).not.toBe(null);
+
+    await page.goto("http://127.0.0.1:8080");
   });
 
-  it.skip(`Testing 'past journal entry' button`, async () => {
+  it(`Testing 'past journal entry' button`, async () => {
     console.log(`Testing 'past journal entry' button`);
 
-    // TODO: test that 'past journal entry' button takes user to correct page
+    let pastButton = await page.$(`.home-buttons[onclick="location.href='./pages/past-entries.html'"]`);
+    await pastButton.click();
+
+    await page.waitForSelector(".calendar");
+
+    let calendar = await page.$(".calendar");
+
+    expect(calendar).not.toBe(null);
+
+    await page.goto("http://127.0.0.1:8080");
   });
 
   it.skip(`Testing 'Home' button`, async () => {


### PR DESCRIPTION
## What does this PR do and why?
This PR adds additional E2E tests which test the "create new card" and "view past journal entries" buttons on the homepage

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- E2E and unit tests pass locally
- See Github actions tests

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules