### PR TITLE
Limit entries to one per day and fixed card submission issue

### DIFF
--- a/script/cardClass.js
+++ b/script/cardClass.js
@@ -153,8 +153,10 @@ export class Card {
       alt: this.model.alt,
     };
 
-    if(this.dailyLimitMet(new Date(entry.date))){
-      alert("You have already submitted an entry for today, come back tomorrow!");
+    if (this.dailyLimitMet(new Date(entry.date))) {
+      alert(
+        "You have already submitted an entry for today, come back tomorrow!",
+      );
       return;
     }
 
@@ -190,25 +192,25 @@ export class Card {
     }
   }
   /**
-  * Checks if an entry has already been submitted for this date
-  * @param {Date} date - date to check
-  * @return {boolean} true if an entry for this date already exists, false otherwise
-  */
+   * Checks if an entry has already been submitted for this date
+   * @param {Date} date - date to check
+   * @return {boolean} true if an entry for this date already exists, false otherwise
+   */
   dailyLimitMet(date) {
     const entries = localStorage.getItem("journalEntries");
-    if(entries){
+    if (entries) {
       const parsed = JSON.parse(entries);
       for (const element of parsed) {
         let curDate = new Date(element.date);
         if (
-            curDate.getDate() == date.getDate() &&
-            curDate.getMonth() == date.getMonth() && 
-            curDate.getFullYear() == date.getFullYear()
-          ) {
-              return true;
+          curDate.getDate() == date.getDate() &&
+          curDate.getMonth() == date.getMonth() &&
+          curDate.getFullYear() == date.getFullYear()
+        ) {
+          return true;
         }
-      };
-    } 
+      }
+    }
     return false;
   }
 

--- a/script/promptSubmit.js
+++ b/script/promptSubmit.js
@@ -83,6 +83,5 @@ function handleSubmitCard() {
   });
 }
 
-
 // Export functions for potential use in other scripts
-export {  handleSubmitCard, saveJournalEntry };
+export { handleSubmitCard, saveJournalEntry };


### PR DESCRIPTION
## What does this PR do and why?
The user is limited to one entry per day. Additionally, the duplicate event listener is removed so the card submission error is fixed. This is needed because card rendering and the delete button in the past entries page dont work when there are multiple submissions per day. 

Fixes #101 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Screenshots or screen recordings

<!---
Screenshots are required for UI changes, and strongly recommended for all other merge requests.
-->

| Before | After  |
| ------ | ------ |
|        |        |

<!--
OPTIONAL: For responsive UI changes, you can use the viewport size table below.
Delete this table if not needed or delete rows that are not relevant to your changes.

| Viewport size   | Before     | After      |
| ----------------| ---------- | ---------- |
| `xs` (<576px)   |            |            |
| `sm` (>=576px)  |            |            |
| `md` (>=768px)  |            |            |
| `lg` (>=992px)  |            |            |
| `xl` (>=1200px) |            |            |
-->

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested in browser. If you try to create another card on the same day that you've already made a submission, an alert is given and the submission is cancelled. 
**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

