### PR TITLE
fix: card ids were in the wrong format

### DIFF
--- a/script/cardModel.js
+++ b/script/cardModel.js
@@ -1,6 +1,6 @@
 export class CardModel {
   constructor(data = {}) {
-    this._id = data.id || crypto.randomUUID();
+    this._id = data.id || Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     this._prompt = data.prompt || null;
     this._response = data.response || "";
     this._date = data.date ? new Date(data.date) : new Date();

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         prompt: null,
         response: "",
         date: new Date().toISOString().split("T")[0],
+        id: new Date().getTime()
       },
     });
 

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         prompt: null,
         response: "",
         date: new Date().toISOString().split("T")[0],
-        id: new Date().getTime()
+        id: new Date().getTime(),
       },
     });
 


### PR DESCRIPTION
## What does this PR do and why?
The card ids defaulted to a bad format for the card favoriting and deletion. This fix makes it so cards default to an integer id rather than a crypto UUID.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots or screen recordings

<!---
Screenshots are required for UI changes, and strongly recommended for all other merge requests.
-->

| Before | After  |
| ------ | ------ |
|        |        |

<!--
OPTIONAL: For responsive UI changes, you can use the viewport size table below.
Delete this table if not needed or delete rows that are not relevant to your changes.

| Viewport size   | Before     | After      |
| ----------------| ---------- | ---------- |
| `xs` (<576px)   |            |            |
| `sm` (>=576px)  |            |            |
| `md` (>=768px)  |            |            |
| `lg` (>=992px)  |            |            |
| `xl` (>=1200px) |            |            |
-->

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Fixes errors that occurred when deleting a card.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

