### PR TITLE
fix: past entries text overflow and dynamic sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Prompted</title>
     <link rel="stylesheet" href="./style/general.css">
     <link rel="stylesheet" href="./style/home.css">
-    <link rel="icon" type="image/x-icon" href="/images/journal-icon.ico">
+    <link rel="icon" type="image/x-icon" href="./images/journal-icon.ico">
 </head>
 <body>
     <nav>

--- a/pages/create-card.html
+++ b/pages/create-card.html
@@ -10,7 +10,7 @@
     <script type="module" src="../script/promptGen.js"></script>
     <script type="module" src="../script/promptEdit.js"></script>
     <script type="module" src="../script/motivationText.js"></script>
-    <link rel="icon" type="image/x-icon" href="/images/journal-icon.ico">
+    <link rel="icon" type="image/x-icon" href="../images/journal-icon.ico">
 </head>
 <body>
     <nav>

--- a/pages/past-entries.html
+++ b/pages/past-entries.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../style/past-entries.css" >
     <link rel="stylesheet" href="../style/general.css">
     <link rel="stylesheet" href="../style/past-entries-card.css">
-    <link rel="icon" type="image/x-icon" href="/images/journal-icon.ico">
+    <link rel="icon" type="image/x-icon" href="../images/journal-icon.ico">
     <!-- <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" /> -->
 </head>
 <body>

--- a/pages/recap.html
+++ b/pages/recap.html
@@ -5,7 +5,7 @@
   <title>Shuffle Recap</title>
   <link rel="stylesheet" href="../style/general.css"/>
   <link rel="stylesheet" href="../style/recap.css"/>
-  <link rel="icon" type="image/x-icon" href="/images/journal-icon.ico">
+  <link rel="icon" type="image/x-icon" href="../images/journal-icon.ico">
   <!-- <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" /> -->
 </head>
 <body>

--- a/pages/settings.html
+++ b/pages/settings.html
@@ -5,7 +5,7 @@
     <title>Settings</title>
     <link rel="stylesheet" href="../style/general.css" />
     <link rel="stylesheet" href="../style/settings.css" />
-    <link rel="icon" type="image/x-icon" href="/images/journal-icon.ico">
+    <link rel="icon" type="image/x-icon" href="../images/journal-icon.ico">
     <!-- <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" /> -->
 </head>
 <body>

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -83,6 +83,8 @@ header button {
     font-size: 0.8em;
     padding: 0.5em;
     border-radius: 0.5em;
+    color: #666;
+    font: 500 0.8em 'Lucida Sans', sans-serif;
 }
 
 .cal-body {

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -41,6 +41,7 @@ main {
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 60vw;
     height: auto;
     flex-direction: column;
     padding: 1em; 
@@ -56,6 +57,7 @@ header {
     align-items: center;
     width: 80%;
     height: 4vh;
+    margin: 1vh;
 }
 
 .month-year {
@@ -91,12 +93,11 @@ header button {
 .days {
     display: grid;
     grid-template-columns: repeat(7,1fr);
-    margin: 0.5vh 0;
+    margin: 1vh;
 }
 
 .day {
     text-align: center;
-    padding: 0.5em 0;
     color: black;
     font-weight: 550;
 }
@@ -105,8 +106,8 @@ header button {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     width: 100%;
-    margin-top: 1vh;
-    margin-bottom: 1vh;
+    margin: 1vh;
+    padding: 0.5vh;
     gap: 0.2vh;
     box-sizing: border-box;
     border: 0.2vh solid black;

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -172,6 +172,8 @@ header button {
     cursor: pointer;
     border: none;
     font-size: 1rem;
+    font-weight: 500;
+    font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
 }
 
 #displayed-card-container {

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -27,7 +27,7 @@ main {
     border-width: 0.3ch;
     border-radius: 1em;
     padding: 1em 1.2em;
-    font-size: 0.75rem;
+    font-size: 1rem;
 }
 
 #search-input:focus {
@@ -169,7 +169,8 @@ header button {
     background-repeat: no-repeat;
     cursor: pointer;
     border: none;
-    font-size: 1rem;
+    font-size: 1.2rem;
+    text-align: center;
     font-weight: 500;
     font-family: 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
 }

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -3,7 +3,7 @@ body {
 }
 
 main {
-    padding: 2%;
+    padding: 2em;
     min-height: 100vh;
     width: 100%;
     display: flex;
@@ -24,8 +24,8 @@ main {
     border-color: #f3d189;
     background-color: #fff6e3;
     border-style: solid;
-    border-width: 2px;
-    border-radius: 10px;
+    border-width: 0.3ch;
+    border-radius: 1em;
     padding: 1em 1.2em;
     font-size: 0.75rem;
 }
@@ -41,11 +41,10 @@ main {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 60vw;
     height: auto;
     flex-direction: column;
-    padding: 10px;
-    border-radius: 10px;
+    padding: 1em; 
+    border-radius: 1em;
     border-color:#f3d189;
     border-style: solid;
     border-width: 0.3ch;
@@ -55,15 +54,15 @@ header {
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 10px;
-    width: 100%;
+    width: 80%;
+    height: 4vh;
 }
 
 .month-year {
     text-align: center;
-    font-weight: 300;
+    font-weight: 600;
     font-size: 1.5rem;
-    width: 150px;
+    width: 100%;
 }
 
 header button {
@@ -71,14 +70,17 @@ header button {
     align-items: center;
     justify-content: center;
     border-style: solid;
-    border-width: 0.2ch;
+    border-width: 0.2vh;
     border-color: #f3d189;
     background-color: #fff6e3;
     cursor: pointer;
-    width: 20%;
-    height: 40px;
-    font-size: x-large;
-
+    width: 50vh;
+    min-width: 2.5em;
+    max-width: 5em;
+    height: 100%;
+    font-size: 0.8em;
+    padding: 0.5em;
+    border-radius: 0.5em;
 }
 
 .cal-body {
@@ -89,43 +91,57 @@ header button {
 .days {
     display: grid;
     grid-template-columns: repeat(7,1fr);
-    margin-top: 10px;
+    margin: 0.5vh 0;
 }
 
 .day {
     text-align: center;
-    padding: 5px;
+    padding: 0.5em 0;
     color: black;
-    font-weight: 500;
+    font-weight: 550;
 }
 
 .dates {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     width: 100%;
-    margin-top: 5px;
-    border: 0.25px solid black;
+    margin-top: 1vh;
+    margin-bottom: 1vh;
+    gap: 0.2vh;
+    box-sizing: border-box;
+    border: 0.2vh solid black;
 }
 
 .date {
+    width: 100%;
+    height: 100%;
     aspect-ratio: 3/2;
-    margin: 0;
-    padding: 0;
+    margin: 0.2vh;
+    padding: 0.2em 0.2em;
     cursor: pointer;
     font-weight: 600;
-    border: 1px solid black;
-    border-radius: 0;
+    border: 0.1ch solid #f3d189;
+    border-radius: 0.2em;
     box-sizing: border-box;
     position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 1em;
 }
 
 .date::after {
     content: attr(data-day);
     position: absolute;
-    bottom: 4px;
-    right: 6px;
+    bottom: 0.3ch;
+    right: 0.5ch;
     font-size: 0.5em;
     color: black;
+    background: #fff6e3;
+    padding: 0 0.2em;
+    border-radius: 0.2em;
+    max-width: 80%;
+    white-space: nowrap;
 }
 
 .date.active {
@@ -158,7 +174,7 @@ header button {
 }
 
 #displayed-card-container {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 4/3;
     width: 100%;            /* Start by filling container width */
     max-width: 40rem;       /* Don't go above this */
     max-height: 15rem;
@@ -190,19 +206,19 @@ placeholder for calendar entries when favorited
 .search-results {
   background-color: #fff6e3;
   border: 0.3ch solid #f3d189;
-  border-radius: 10px;
+  border-radius: 1em;
   width: 60vw;
   margin-bottom: 2%;
-  padding: 20px;
+  padding: 1em;
 }
 
 .search-results-header {
-  margin-bottom: 20px;
+  margin-bottom: 2%;
   text-align: center;
 }
 
 .search-results-header h3 {
-  margin: 0 0 10px 0;
+  margin: 0 0 1em 0;
   color: #333;
   font-size: 1.5rem;
 }
@@ -216,26 +232,26 @@ placeholder for calendar entries when favorited
 .search-results-list {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 1.5em;
 }
 
 .search-result-item {
   background-color: white;
-  border: 2px solid #f3d189;
-  border-radius: 8px;
-  padding: 15px;
+  border: 0.3vh solid #f3d189;
+  border-radius: 0.5em;
+  padding: 1em;
   transition: all 0.3s ease;
 }
 
 .search-result-item:hover {
   border-color: #e6c373;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.4ch 0.8ch rgba(0, 0, 0, 0.1);
 }
 
 .search-result-content {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.2em;
 }
 
 .search-result-date {
@@ -257,19 +273,19 @@ placeholder for calendar entries when favorited
 
 .search-highlight {
   background-color: #ffee8c;
-  padding: 1px 2px;
-  border-radius: 3px;
+  padding: 0.1ch 0.2ch;
+  border-radius: 0.2em;
   font-weight: bold;
 }
 
 .no-results {
   text-align: center;
-  padding: 40px 20px;
+  padding: 2em;
   color: #666;
 }
 
 .no-results h3 {
-  margin: 0 0 15px 0;
+  margin: 0 0 0.2ch 0;
   color: #333;
   font-size: 1.3rem;
 }
@@ -287,7 +303,7 @@ placeholder for calendar entries when favorited
   }
   
   .search-result-item {
-    padding: 12px;
+    padding: 0.8em;
   }
   
   .search-result-prompt,
@@ -306,6 +322,6 @@ placeholder for calendar entries when favorited
   }
   
   .search-result-content {
-    gap: 6px;
+    gap: 0.1em;
   }
 }

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -84,7 +84,7 @@ header button {
     padding: 0.5em;
     border-radius: 0.5em;
     color: #666;
-    font: 500 0.8em 'Lucida Sans', sans-serif;
+    font: 500 0.8em sans-serif;
 }
 
 .cal-body {
@@ -128,9 +128,8 @@ header button {
     box-sizing: border-box;
     position: relative;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 1em;
+    overflow-wrap: break-word;
+    font-size: 2vw;
 }
 
 .date::after {

--- a/style/past-entries.css
+++ b/style/past-entries.css
@@ -63,7 +63,7 @@ header {
 .month-year {
     text-align: center;
     font-weight: 600;
-    font-size: 1.5rem;
+    font-size: 2vw;
     width: 100%;
 }
 
@@ -76,15 +76,12 @@ header button {
     border-color: #f3d189;
     background-color: #fff6e3;
     cursor: pointer;
-    width: 50vh;
-    min-width: 2.5em;
-    max-width: 5em;
+    width: 10vw;
     height: 100%;
-    font-size: 0.8em;
+    font-size: 1vw;
     padding: 0.5em;
     border-radius: 0.5em;
     color: #666;
-    font: 500 0.8em sans-serif;
 }
 
 .cal-body {


### PR DESCRIPTION
## What does this PR do and why?
Text and calendar grid in past entries page was changed into dynamic sizing for compatibility with different size screens and devices.

Fixes #128 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots or screen recordings

![image](https://github.com/user-attachments/assets/c1f1cdac-56af-4b87-8820-3d25ed6294e9)

![image](https://github.com/user-attachments/assets/4b16271b-1c6d-4916-b9aa-5c5460ae5402)

# How Has This Been Tested?

- [x] Tested and reviewed locally
- [x] Passed through W3C css validator

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

