### PR TITLE
Card prompt submission fix

### DIFF
--- a/pages/create-card.html
+++ b/pages/create-card.html
@@ -37,7 +37,7 @@
         </div>
 
         <div class="prompt-bar">
-            <prompt-box>Example Prompt: What moment from this week made you feel truly seen or understood - no matter how small</prompt-box>
+            <prompt-box></prompt-box>
             <div class="prompt-buttons">
                 <button id="newPromptBtn">New Prompt</button>
                 <button id="editPromptBtn">Edit Prompt</button>

--- a/script/cardClass.js
+++ b/script/cardClass.js
@@ -296,6 +296,11 @@ export class Card {
         if (promptBox) {
           promptBox.textContent = newPrompt;
         }
+
+        const form = document.querySelector(".card-back form");
+        if (form) {
+          form.setAttribute("data-prompt", newPrompt);
+        }
       } catch (error) {
         console.error("Error generating new prompt:", error);
       }

--- a/script/cardClass.js
+++ b/script/cardClass.js
@@ -292,7 +292,7 @@ export class Card {
         }
 
         // Update the prompt box if it exists
-        const promptBox = document.querySelector(".prompt-box");
+        const promptBox = document.querySelector("prompt-box");
         if (promptBox) {
           promptBox.textContent = newPrompt;
         }

--- a/script/cardModel.js
+++ b/script/cardModel.js
@@ -1,6 +1,6 @@
 export class CardModel {
   constructor(data = {}) {
-    this._id = data.id || crypto.randomUUID();
+    this._id = data.id || Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     this._prompt = data.prompt || null;
     this._response = data.response || "";
     this._date = data.date ? new Date(data.date) : new Date();

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Add the prompt text to the form element for the non-flippable card
     const updatePromptDisplay = () => {
       const form = document.querySelector(".card-back form");
-      const promptText = document.querySelector("prompt-box").textContent;
+      const promptText = journalCard.model.prompt;
       if (form && promptText) {
         form.setAttribute("data-prompt", promptText || "");
       }

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -18,6 +18,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Render the card
     await journalCard.render();
 
+    // Force sync between prompts upon page load
+    let initPromptBox = document.querySelector("prompt-box");
+    if (initPromptBox) {
+      initPromptBox.textContent = journalCard.model.prompt;
+    }
+
     // Add the prompt text to the form element for the non-flippable card
     const updatePromptDisplay = () => {
       const form = document.querySelector(".card-back form");

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -27,7 +27,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Add the prompt text to the form element for the non-flippable card
     const updatePromptDisplay = () => {
       const form = document.querySelector(".card-back form");
-      journalCard.model.prompt = document.querySelector("prompt-box").textContent.trim();
+      journalCard.model.prompt = document
+        .querySelector("prompt-box")
+        .textContent.trim();
       const promptText = journalCard.model.prompt;
       if (form && promptText) {
         form.setAttribute("data-prompt", promptText || "");

--- a/script/create-card.js
+++ b/script/create-card.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Add the prompt text to the form element for the non-flippable card
     const updatePromptDisplay = () => {
       const form = document.querySelector(".card-back form");
+      journalCard.model.prompt = document.querySelector("prompt-box").textContent.trim();
       const promptText = journalCard.model.prompt;
       if (form && promptText) {
         form.setAttribute("data-prompt", promptText || "");

--- a/script/promptEdit.js
+++ b/script/promptEdit.js
@@ -15,19 +15,40 @@ function makePromptEditable() {
 
   // Toggle between edit and save modes
   editPromptBtn.addEventListener("click", () => {
-    if (promptBox.getAttribute("contenteditable") === "true") {
-      // Save mode - make not editable
+    const isEditing = promptBox.getAttribute("contenteditable") === "true";
+
+    if (isEditing) {
+      // SAVE MODE
       promptBox.setAttribute("contenteditable", "false");
       promptBox.classList.remove("editing");
       editPromptBtn.textContent = "Edit Prompt";
+
+      // Get the updated prompt
+      const newPrompt = promptBox.textContent.trim();
+
+      // Update model and card
+      if (window.journalCard) {
+        window.journalCard.model.prompt = newPrompt;
+
+        const cardPromptEl = window.journalCard.elements.card?.querySelector(".prompt");
+        if (cardPromptEl) {
+          cardPromptEl.textContent = newPrompt;
+        }
+
+        const form = document.querySelector(".card-back form");
+        if (form) {
+          form.setAttribute("data-prompt", newPrompt);
+        }
+      }
     } else {
-      // Edit mode - make editable
+      // EDIT MODE
       promptBox.setAttribute("contenteditable", "true");
       promptBox.classList.add("editing");
       promptBox.focus();
       editPromptBtn.textContent = "Save Prompt";
     }
   });
+
 }
 
 /**

--- a/script/promptEdit.js
+++ b/script/promptEdit.js
@@ -30,7 +30,8 @@ function makePromptEditable() {
       if (window.journalCard) {
         window.journalCard.model.prompt = newPrompt;
 
-        const cardPromptEl = window.journalCard.elements.card?.querySelector(".prompt");
+        const cardPromptEl =
+          window.journalCard.elements.card?.querySelector(".prompt");
         if (cardPromptEl) {
           cardPromptEl.textContent = newPrompt;
         }
@@ -48,7 +49,6 @@ function makePromptEditable() {
       editPromptBtn.textContent = "Save Prompt";
     }
   });
-
 }
 
 /**


### PR DESCRIPTION
## What does this PR do and why?
The card prompt given to the user did not match what was saved in local storage or what was shown in past entries. Additionally, the edit button feature did not work as the prompt was never saved to the card. This pr fixes both issues

Fixes #142 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots or screen recordings
# Before
![image](https://github.com/user-attachments/assets/592b9b1f-d20a-44fe-b0f0-1deeda432f79)

![image](https://github.com/user-attachments/assets/5e078a7c-8c24-48db-a6de-d714d6066f1c)

![image](https://github.com/user-attachments/assets/8634cec8-91de-408f-b5b6-b1c34aa64c6f)
![image](https://github.com/user-attachments/assets/7c54e415-b3a5-4f07-9970-8e6ba1475f52)

# After
![image](https://github.com/user-attachments/assets/a2eadf6a-4566-480e-a0d4-497076bee5a6)
![image](https://github.com/user-attachments/assets/d2240689-c79e-4317-909e-10b18ac4316e)

![image](https://github.com/user-attachments/assets/4639b595-cd88-4a4c-9562-a7777765c635)
![image](https://github.com/user-attachments/assets/9f0b97f3-9a7d-40a7-8fcc-bc1fe78ea680)

<!---

<!--
OPTIONAL: For responsive UI changes, you can use the viewport size table below.
Delete this table if not needed or delete rows that are not relevant to your changes.

| Viewport size   | Before     | After      |
| ----------------| ---------- | ---------- |
| `xs` (<576px)   |            |            |
| `sm` (>=576px)  |            |            |
| `md` (>=768px)  |            |            |
| `lg` (>=992px)  |            |            |
| `xl` (>=1200px) |            |            |
-->

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested in browser and with manual e2e testing. 

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

