### PR TITLE
chore: remove references to unused feature pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,12 +18,6 @@
         <a href="./pages/past-entries.html">
             <img src="./images/calendar-icon.svg" alt="past entries button"/>
         </a>
-        <a href="./pages/recap.html">
-            <img src="./images/shuffle-icon.svg" alt="recap button"/>
-        </a>
-        <a href="./pages/settings.html">
-            <img src="./images/settings-icon.svg" alt="settings button"/>
-        </a>
     </nav>
     <main>
         <h1>Home</h1>

--- a/pages/create-card.html
+++ b/pages/create-card.html
@@ -22,13 +22,7 @@
         </a>
         <a href="past-entries.html">
             <img src="../images/calendar-icon.svg" alt="past entries button"/>
-        </a>
-        <a href="recap.html">
-            <img src="../images/shuffle-icon.svg" alt="recap button"/>
-        </a>
-        <a href="settings.html">
-            <img src="../images/settings-icon.svg" alt="settings button"/>
-        </a>        
+        </a>      
     </nav>
 
     <main>

--- a/pages/past-entries.html
+++ b/pages/past-entries.html
@@ -19,13 +19,7 @@
         </a>
         <a href="past-entries.html">
             <img src="../images/calendar-icon.svg" alt="past entries button"/>
-        </a>
-        <a href="recap.html">
-            <img src="../images/shuffle-icon.svg" alt="recap button"/>
-        </a>
-        <a href="settings.html">
-            <img src="../images/settings-icon.svg" alt="settings button"/>
-        </a>        
+        </a>      
     </nav>
     <main>
       <div class="search-bar">

--- a/test/e2e/createcard.e2e.test.js
+++ b/test/e2e/createcard.e2e.test.js
@@ -22,12 +22,10 @@ describe("Test basic user flow from Create Card page", () => {
       });
     });
 
-    expect(navButtons.length).toBe(5);
+    expect(navButtons.length).toBe(3);
     expect(navButtons.includes("../images/home-icon.svg")).toBe(true);
     expect(navButtons.includes("../images/edit-icon.svg")).toBe(true);
     expect(navButtons.includes("../images/calendar-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/shuffle-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/settings-icon.svg")).toBe(true);
 
     // top bar
     const newPromptBtn = await page.$("#newPromptBtn");

--- a/test/e2e/homepage.e2e.test.js
+++ b/test/e2e/homepage.e2e.test.js
@@ -15,12 +15,10 @@ describe("Test basic user flow from homepage", () => {
       });
     });
 
-    expect(navButtons.length).toBe(5);
-    expect(navButtons.includes("./images/home-icon.svg")).toBe(true);
-    expect(navButtons.includes("./images/edit-icon.svg")).toBe(true);
-    expect(navButtons.includes("./images/calendar-icon.svg")).toBe(true);
-    expect(navButtons.includes("./images/shuffle-icon.svg")).toBe(true);
-    expect(navButtons.includes("./images/settings-icon.svg")).toBe(true);
+    expect(navButtons.length).toBe(3);
+    expect(navButtons.includes("../images/home-icon.svg")).toBe(true);
+    expect(navButtons.includes("../images/edit-icon.svg")).toBe(true);
+    expect(navButtons.includes("../images/calendar-icon.svg")).toBe(true);
 
     console.log("Checking that journal entry buttons loaded...");
 

--- a/test/e2e/homepage.e2e.test.js
+++ b/test/e2e/homepage.e2e.test.js
@@ -16,9 +16,9 @@ describe("Test basic user flow from homepage", () => {
     });
 
     expect(navButtons.length).toBe(3);
-    expect(navButtons.includes("../images/home-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/edit-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/calendar-icon.svg")).toBe(true);
+    expect(navButtons.includes("./images/home-icon.svg")).toBe(true);
+    expect(navButtons.includes("./images/edit-icon.svg")).toBe(true);
+    expect(navButtons.includes("./images/calendar-icon.svg")).toBe(true);
 
     console.log("Checking that journal entry buttons loaded...");
 

--- a/test/e2e/pastentries.e2e.test.js
+++ b/test/e2e/pastentries.e2e.test.js
@@ -13,12 +13,10 @@ describe("Test basic user flow from Past Entries page", () => {
       });
     });
 
-    expect(navButtons.length).toBe(5);
+    expect(navButtons.length).toBe(3);
     expect(navButtons.includes("../images/home-icon.svg")).toBe(true);
     expect(navButtons.includes("../images/edit-icon.svg")).toBe(true);
     expect(navButtons.includes("../images/calendar-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/shuffle-icon.svg")).toBe(true);
-    expect(navButtons.includes("../images/settings-icon.svg")).toBe(true);
 
     // Entry buttons
   });


### PR DESCRIPTION
## What does this PR do and why?
To make our page have full functionality and a good user experience, this PR removes references to feature pages that have not been implemented yet (settings and recap)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots or screen recordings

![image](https://github.com/user-attachments/assets/583583c0-3098-4d78-b171-1653c489f8cb)

# How Has This Been Tested?

- [x] Tested locally, this change does not break or change any functionalities

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

